### PR TITLE
Release v1.0.2 - PHP 8.5 upgrade

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set version-date tag
         id: tag
         run: |
-          VERSION="v1.0.0"  # Default version if no release tag is found
+          VERSION="v1.0.2"  # Default version if no release tag is found
           if [ ! -z "${{ github.event.release.tag_name }}" ]; then
             VERSION=${{ github.event.release.tag_name }}
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Warp AI configuration
+WARP.md
+
+# Log files
+src/visitors.log


### PR DESCRIPTION
## Release v1.0.2

This release prepares the project for version 1.0.2, reflecting the recent PHP 8.5 upgrade.

### Changes
- Add `.gitignore` to exclude `WARP.md` and `src/visitors.log` from version control
- Update workflow default version to v1.0.2
- Docker image now uses PHP 8.5 (upgraded from 8.4)

### Docker Images
When merged, this will publish:
- `maboni82/external-ip-checker:latest`
- `maboni82/external-ip-checker:v1.0.2-YYYYMMDD`